### PR TITLE
 :sparkles: feat: 화주의 서류 전송 api에 예약 대기 목록에 추가하는 기능 추가

### DIFF
--- a/src/main/kotlin/com/example/dongguktoocean/booking/domain/Booking.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/booking/domain/Booking.kt
@@ -1,0 +1,29 @@
+package com.example.dongguktoocean.booking.domain
+
+import com.example.dongguktoocean.cargo.domain.Cargo
+import com.example.dongguktoocean.container.domain.Container
+import com.example.dongguktoocean.schedule.domain.Schedule
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "Booking")
+data class Booking(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null, // 선박 예약 ID
+
+    @Column(nullable = false)
+    val status: String, // 상태
+
+    @OneToOne
+    @JoinColumn(name = "cargo_id", nullable = false) // 화물 ID 외래키
+    val cargo: Cargo, // Cargo 엔티티 참조
+
+    @OneToOne
+    @JoinColumn(name = "container_id", nullable = true) // 컨테이너 ID 외래키 (nullable)
+    val container: Container? = null, // Container 엔티티 참조 (nullable)
+
+    @ManyToOne
+    @JoinColumn(name = "ship_schedule_id", nullable = false) // 선박 스케줄 ID 외래키
+    val shipSchedule: Schedule // ShipSchedule 엔티티 참조
+)

--- a/src/main/kotlin/com/example/dongguktoocean/booking/repository/BookingRepository.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/booking/repository/BookingRepository.kt
@@ -1,0 +1,6 @@
+package com.example.dongguktoocean.booking.repository
+
+import com.example.dongguktoocean.booking.domain.Booking
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BookingRepository : JpaRepository<Booking, Long>

--- a/src/main/kotlin/com/example/dongguktoocean/container/repository/ContainerRepository.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/container/repository/ContainerRepository.kt
@@ -1,0 +1,7 @@
+package com.example.dongguktoocean.container.repository
+
+
+import com.example.dongguktoocean.container.domain.Container
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ContainerRepository : JpaRepository<Container, Long>

--- a/src/main/kotlin/com/example/dongguktoocean/document/service/InvoiceService.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/document/service/InvoiceService.kt
@@ -1,16 +1,22 @@
 package com.example.dongguktoocean.document.service
 
+import com.example.dongguktoocean.booking.domain.Booking
+import com.example.dongguktoocean.booking.repository.BookingRepository
 import com.example.dongguktoocean.cargo.domain.Cargo
 import com.example.dongguktoocean.cargo.repository.CargoRepository
+import com.example.dongguktoocean.container.domain.Container
+import com.example.dongguktoocean.container.repository.ContainerRepository
 import com.example.dongguktoocean.document.domain.DocumentList
 import com.example.dongguktoocean.document.domain.InvoiceDoc
 import com.example.dongguktoocean.document.dto.InvoiceDocRequest
 import com.example.dongguktoocean.document.repository.DocumentListRepository
 import com.example.dongguktoocean.document.repository.InvoiceDocRepository
 import com.example.dongguktoocean.schedule.repository.ScheduleRepository
+import com.example.dongguktoocean.ship.repository.ShipRepository
 import com.example.dongguktoocean.user.repository.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.jvm.internal.impl.descriptors.Visibilities.Private
 
 @Service
 class InvoiceDocService(
@@ -18,7 +24,9 @@ class InvoiceDocService(
     private val scheduleRepository: ScheduleRepository,
     private val userRepository: UserRepository,
     private val documentListRepository: DocumentListRepository,
-    private val cargoRepository: CargoRepository
+    private val cargoRepository: CargoRepository,
+    private val containerRepository: ContainerRepository,
+    private val bookingRepository: BookingRepository
 ) {
     @Transactional
     fun createInvoiceDoc(id: Long, request: InvoiceDocRequest) {
@@ -28,6 +36,7 @@ class InvoiceDocService(
 
         val shipSchedule = scheduleRepository.findById(request.shipScheduleId)
             .orElseThrow{IllegalArgumentException("해당 ID의 ShipSchedule이 존재하지 않습니다.")}
+        val ship = shipSchedule.ship_id
 
 
         // InvoiceDoc 생성
@@ -40,7 +49,7 @@ class InvoiceDocService(
             price = request.price,
             sender = request.sender,
             receiver = request.receiver,
-            ship = shipSchedule.shipCode,
+            ship = ship.name,
             load_port = shipSchedule.loadingPort,
             dest_port = shipSchedule.destinationPort,
         )
@@ -61,6 +70,23 @@ class InvoiceDocService(
             cargoType = request.cargo_type,
             cargoWeight = request.cargo_weight
         )
-        cargoRepository.save(cargo)
+        val savedCargo=cargoRepository.save(cargo)
+
+        val container = Container(
+            field = "00",
+            field2 = "00",
+            ship = ship
+        )
+        val savedContainer = containerRepository.save(container)
+
+        val booking = Booking(
+            status = "대기",
+            cargo = savedCargo,
+            shipSchedule = shipSchedule,
+            container =savedContainer
+
+        )
+        val savedBooking = bookingRepository.save(booking)
+
     }
 }

--- a/src/main/kotlin/com/example/dongguktoocean/schedule/domain/Schedule.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/schedule/domain/Schedule.kt
@@ -1,5 +1,6 @@
 package com.example.dongguktoocean.schedule.domain
 
+import com.example.dongguktoocean.ship.domain.Ship
 import jakarta.persistence.*
 
 
@@ -10,8 +11,9 @@ data class Schedule(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
 
-    @Column(nullable = false)
-    val shipCode: String,
+    @ManyToOne
+    @JoinColumn(name = "ship_id", nullable = false) // 선박 스케줄 ID 외래키
+    val ship_id: Ship, // Ship 엔티티 참조
 
     @Column(nullable = false)
     val captain: String,

--- a/src/main/kotlin/com/example/dongguktoocean/schedule/dto/UploadRequesetDto.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/schedule/dto/UploadRequesetDto.kt
@@ -1,7 +1,7 @@
 package com.example.dongguktoocean.schedule.dto
 
 data class UploadRequestDto(
-    val shipCode: String,
+    val ship_id: Long,
     val captain: String,
     val loadingPort: String,
     val destinationPort: String,

--- a/src/main/kotlin/com/example/dongguktoocean/schedule/service/ShipScheduleService.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/schedule/service/ShipScheduleService.kt
@@ -3,6 +3,7 @@ package com.example.dongguktoocean.schedule.service
 import com.example.dongguktoocean.schedule.domain.Schedule
 import com.example.dongguktoocean.schedule.dto.*
 import com.example.dongguktoocean.schedule.repository.ShipScheduleRepository
+import com.example.dongguktoocean.ship.repository.ShipRepository
 import com.example.dongguktoocean.user.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
@@ -10,7 +11,8 @@ import org.springframework.stereotype.Service
 @Service
 class ShipScheduleService(
     private val userRepository: UserRepository,
-    private val scheduleRepository: ShipScheduleRepository
+    private val scheduleRepository: ShipScheduleRepository,
+    private val shipRepository: ShipRepository
 ) {
     fun searchSchedules(request: SearchRequestDto): SearchResponseDto {
         val schedules: List<Schedule> = scheduleRepository.findSchedules(
@@ -29,15 +31,17 @@ class ShipScheduleService(
 
     @Transactional
     fun uploadSchedule(request: UploadRequestDto) : ScheduleUploadResponseDto{
-        val schedule: Schedule = Schedule(
-            null,
-            request.shipCode,
-            request.captain,
-            request.loadingPort,
-            request.destinationPort,
-            request.departureTime,
-            request.arrivalTime,
-            request.shippingCompany
+        val ship = shipRepository.findById(request.ship_id).orElseThrow{ IllegalArgumentException("해당 ID의 선박이 존재하지 않습니다.") }
+
+        val schedule = Schedule(
+
+            ship_id=ship,
+            captain = request.captain,
+            loadingPort = request.loadingPort,
+            destinationPort = request.destinationPort,
+            departureTime = request.departureTime,
+            arrivalTime = request.arrivalTime,
+            shippingCompany = request.shippingCompany
         )
         scheduleRepository.save(schedule)
         val response : ScheduleUploadResponseDto = ScheduleUploadResponseDto(

--- a/src/main/kotlin/com/example/dongguktoocean/ship/repository/ShipRepository.kt
+++ b/src/main/kotlin/com/example/dongguktoocean/ship/repository/ShipRepository.kt
@@ -1,9 +1,7 @@
 package com.example.dongguktoocean.ship.repository
 
 import com.example.dongguktoocean.ship.domain.Ship
-import org.springframework.stereotype.Repository
 import org.springframework.data.jpa.repository.JpaRepository
 
 
-@Repository
-interface ShipRepository : JpaRepository<Ship, String> // ship_id를 PK로 사용
+interface ShipRepository : JpaRepository<Ship, Long> // ship_id를 PK로 사용


### PR DESCRIPTION
## 관련 이슈
17-feature-화물-정보-등록-api에-예약-정보-저장-기능-추가

- Resolves :

## 작업 사항
Booking domain, repository
Container domain, repository

Schedule domain에 shipCode제거후 ship_id추가
ShipScheduleService 로직 수정
uploadRequestDto shipCode 제거후 ship_id 추가
InvoiceDocService Booking 테이블과 Container 테이블 생성 로직 추가

-

## 참고 사항
ship_schedule에 선박 id 추가하는 과정에서 웅희 코드에 맞지 않는 부분이 생겨서 수정했습니다 
uploadRequestDto 수정으로 인해 Postman에 선박스케줄 업로드 API body부분 수정되었습니다.